### PR TITLE
[fix] make spaetzle search case-insensitive

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -12,7 +12,7 @@ import re
 cache = TTLCache(maxsize=1, ttl=3600)
 app = FastAPI()
 templates = Jinja2Templates(directory="template")
-regex = re.compile(r'Spätzle <sup>([^/]*)<\/sup>')
+regex = re.compile(r'spätzle <sup>([^/]*)<\/sup>', re.IGNORECASE)
 
 @cached(cache)
 def checkMensa():
@@ -28,7 +28,7 @@ def checkMensa():
 
     spaetzle = None
     for m in meals:
-        if "Spätzle" in m.text:
+        if "spätzle" in m.text.lower():
             spaetzle = m
             break
 

--- a/src/api.py
+++ b/src/api.py
@@ -12,7 +12,7 @@ import re
 cache = TTLCache(maxsize=1, ttl=3600)
 app = FastAPI()
 templates = Jinja2Templates(directory="template")
-regex = re.compile(r'spätzle <sup>([^/]*)<\/sup>', re.IGNORECASE)
+regex = re.compile(r'spätzle <sup>([^/]*)</sup>', re.IGNORECASE)
 
 @cached(cache)
 def checkMensa():


### PR DESCRIPTION
When combined words such as "Käsespätzle" are on the menu, the application currently doesn't recognize those as it searches for capital "Spätzle".